### PR TITLE
Use 'Qt::endl' instead of deprecated 'endl'

### DIFF
--- a/QsLogDestFile.cpp
+++ b/QsLogDestFile.cpp
@@ -170,8 +170,12 @@ void QsLogging::FileDestination::write(const LogMessage& message)
         mOutputStream.setCodec(QTextCodec::codecForName("UTF-8"));
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     mOutputStream << utf8Message << endl;
     mOutputStream.flush();
+#else
+    mOutputStream << utf8Message << Qt::endl;
+#endif
 }
 
 bool QsLogging::FileDestination::isValid()

--- a/QsLogSharedLibrary.pro
+++ b/QsLogSharedLibrary.pro
@@ -7,6 +7,7 @@ CONFIG -= app_bundle
 CONFIG += shared
 CONFIG += c++11
 TEMPLATE = lib
+DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000  # disables all the APIs deprecated before Qt 6.0.0
 
 QSLOG_DESTDIR=$$(QSLOG_DESTDIR)
 !isEmpty(QSLOG_DESTDIR) {


### PR DESCRIPTION
As this was the last deprecated symbol in QsLog it now allows to include QsLog in projects that treat using deprecated symbols as an error.